### PR TITLE
fix: 運動メニューAPIのレスポンスキー不一致を修正

### DIFF
--- a/.claude/docs/04-api-specification.md
+++ b/.claude/docs/04-api-specification.md
@@ -524,7 +524,7 @@ Cookie: _psyfit_session=<session_id>
 {
   "status": "success",
   "data": {
-    "assigned_exercises": [
+    "exercises": [
       {
         "id": "uuid",
         "exercise": {

--- a/app/controllers/api/v1/user_exercises_controller.rb
+++ b/app/controllers/api/v1/user_exercises_controller.rb
@@ -46,7 +46,7 @@ module Api
           }
         end
 
-        render_success({ assigned_exercises: assigned_exercises })
+        render_success({ exercises: assigned_exercises })
       end
     end
   end

--- a/frontend_user/src/components/Home.tsx
+++ b/frontend_user/src/components/Home.tsx
@@ -73,13 +73,13 @@ export function Home() {
         ])
 
         if (exercisesRes.status === 'success' && exercisesRes.data) {
-          setExercises(exercisesRes.data.exercises)
+          setExercises(exercisesRes.data.exercises ?? [])
         }
         if (recordsRes.status === 'success' && recordsRes.data) {
-          setTodayRecords(recordsRes.data.records)
+          setTodayRecords(recordsRes.data.records ?? [])
         }
         if (conditionsRes.status === 'success' && conditionsRes.data) {
-          setHasConditionToday(conditionsRes.data.conditions.length > 0)
+          setHasConditionToday((conditionsRes.data.conditions ?? []).length > 0)
         }
       } catch {
         // Silently handle errors for exercise list

--- a/spec/requests/api/v1/user_exercises_spec.rb
+++ b/spec/requests/api/v1/user_exercises_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
 
           expect(response).to have_http_status(:ok)
           expect(json_response['status']).to eq('success')
-          expect(json_response['data']['assigned_exercises'].length).to eq(2)
+          expect(json_response['data']['exercises'].length).to eq(2)
         end
 
         it 'returns exercise details in correct format' do
           get '/api/v1/users/me/exercises'
 
-          first_exercise = json_response['data']['assigned_exercises'].find do |e|
+          first_exercise = json_response['data']['exercises'].find do |e|
             e['id'] == patient_exercise1.id
           end
 
@@ -84,7 +84,7 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
         it 'includes completed_today flag as false when not exercised today' do
           get '/api/v1/users/me/exercises'
 
-          first_exercise = json_response['data']['assigned_exercises'].first
+          first_exercise = json_response['data']['exercises'].first
           expect(first_exercise['completed_today']).to eq(false)
         end
 
@@ -100,10 +100,10 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
           it 'returns completed_today as true for exercised item' do
             get '/api/v1/users/me/exercises'
 
-            completed_exercise = json_response['data']['assigned_exercises'].find do |e|
+            completed_exercise = json_response['data']['exercises'].find do |e|
               e['id'] == patient_exercise1.id
             end
-            not_completed_exercise = json_response['data']['assigned_exercises'].find do |e|
+            not_completed_exercise = json_response['data']['exercises'].find do |e|
               e['id'] == patient_exercise2.id
             end
 
@@ -124,7 +124,7 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
           it 'returns completed_today as false' do
             get '/api/v1/users/me/exercises'
 
-            first_exercise = json_response['data']['assigned_exercises'].find do |e|
+            first_exercise = json_response['data']['exercises'].find do |e|
               e['id'] == patient_exercise1.id
             end
             expect(first_exercise['completed_today']).to eq(false)
@@ -154,8 +154,8 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
           get '/api/v1/users/me/exercises'
 
           expect(response).to have_http_status(:ok)
-          expect(json_response['data']['assigned_exercises'].length).to eq(1)
-          expect(json_response['data']['assigned_exercises'].first['id']).to eq(active_assignment.id)
+          expect(json_response['data']['exercises'].length).to eq(1)
+          expect(json_response['data']['exercises'].first['id']).to eq(active_assignment.id)
         end
       end
 
@@ -165,7 +165,7 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
 
           expect(response).to have_http_status(:ok)
           expect(json_response['status']).to eq('success')
-          expect(json_response['data']['assigned_exercises']).to eq([])
+          expect(json_response['data']['exercises']).to eq([])
         end
       end
 
@@ -191,8 +191,8 @@ RSpec.describe 'Api::V1::UserExercises', type: :request do
         it 'returns only current user exercises' do
           get '/api/v1/users/me/exercises'
 
-          expect(json_response['data']['assigned_exercises'].length).to eq(1)
-          expect(json_response['data']['assigned_exercises'].first['id']).to eq(current_user_exercise.id)
+          expect(json_response['data']['exercises'].length).to eq(1)
+          expect(json_response['data']['exercises'].first['id']).to eq(current_user_exercise.id)
         end
       end
     end


### PR DESCRIPTION
バックエンドが返す `assigned_exercises` キーをフロントエンドが期待する
`exercises` に統一。Home画面で発生していたTypeError (.filter on undefined) を解消。併せて防御的フォールバック(nullish coalescing)を追加。