### PR TITLE
fix: 運動メニューAPI のレスポンス構造をフロントエンド型に合わせてフラット化

### DIFF
--- a/app/controllers/api/v1/user_exercises_controller.rb
+++ b/app/controllers/api/v1/user_exercises_controller.rb
@@ -15,34 +15,25 @@ module Api
 
       # GET /api/v1/users/me/exercises
       # Returns assigned exercises for the current user
+      # Response matches frontend Exercise type (flat structure)
       def index
         patient_exercises = current_user
           .patient_exercises
           .active
           .includes(:exercise)
 
-        today_exercise_ids = ExerciseRecord
-          .where(user_id: current_user.id)
-          .where("completed_at >= ?", Time.current.beginning_of_day)
-          .pluck(:exercise_id)
-          .to_set
-
         assigned_exercises = patient_exercises.map do |pe|
           ex = pe.exercise
           {
-            id: pe.id,
-            target_reps: pe.target_reps,
-            target_sets: pe.target_sets,
-            completed_today: today_exercise_ids.include?(ex.id),
-            exercise: {
-              id: ex.id,
-              name: ex.name,
-              description: ex.description.to_s,
-              video_url: ex.video_url,
-              thumbnail_url: ex.thumbnail_url,
-              duration_seconds: ex.duration_seconds,
-              exercise_type: EXERCISE_TYPE_MAP[ex.exercise_type] || "training"
-            }
+            id: ex.id,
+            name: ex.name,
+            description: ex.description.to_s,
+            video_url: ex.video_url,
+            thumbnail_url: ex.thumbnail_url,
+            duration_seconds: ex.duration_seconds,
+            exercise_type: EXERCISE_TYPE_MAP[ex.exercise_type] || "training",
+            sets: pe.target_sets || ex.recommended_sets,
+            reps: pe.target_reps || ex.recommended_reps
           }
         end
 


### PR DESCRIPTION
UserExercisesController のレスポンスがネスト構造（exercise 内に詳細を格納） だったため、フロントエンドの Exercise 型（フラット構造）と不一致が発生し、
exercise_type が undefined になりグループ分けが失敗、
運動メニューが表示されない問題を修正。