### PR TITLE
feat: ExercisePlayerにセキュア動画ストリーミングを実装

### DIFF
--- a/frontend_user/src/lib/api-client.ts
+++ b/frontend_user/src/lib/api-client.ts
@@ -13,7 +13,8 @@ import type {
   Exercise,
   ExercisesResponse,
   ExerciseRecord,
-  CreateExerciseRecordRequest
+  CreateExerciseRecordRequest,
+  VideoTokenResponse
 } from './api-types'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1'
@@ -119,6 +120,15 @@ class ApiClient {
       method: 'POST',
       body: JSON.stringify(data),
     })
+  }
+
+  // Video streaming endpoints
+  async getVideoToken(exerciseId: string): Promise<ApiResponse<VideoTokenResponse>> {
+    return this.request<VideoTokenResponse>(`/videos/${exerciseId}/token`)
+  }
+
+  getVideoStreamUrl(exerciseId: string, token: string): string {
+    return `${this.baseUrl}/videos/${exerciseId}/stream?token=${encodeURIComponent(token)}`
   }
 }
 

--- a/frontend_user/src/lib/api-types.ts
+++ b/frontend_user/src/lib/api-types.ts
@@ -128,6 +128,13 @@ export interface ExerciseRecordsResponse {
   records: ExerciseRecordWithExercise[]
 }
 
+// Video Token Types
+export interface VideoTokenResponse {
+  token: string
+  expires_at: string
+  exercise_id: string
+}
+
 // Date Filter Params
 export interface DateFilterParams {
   [key: string]: string | undefined

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
     <title>PsyFit - リハビリ運動支援</title>
-    <script type="module" crossorigin src="/assets/index-D6c3CKEl.js"></script>
+    <script type="module" crossorigin src="/assets/index-BGydGBIt.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-CJVGTz8t.css">
   </head>
   <body>


### PR DESCRIPTION
動画再生をトークン認証経由のストリーミングURLに変更。
exercise.video_urlの直接参照を廃止し、一時トークンを取得して
/api/v1/videos/:id/stream?token=xxx 経由で配信する。