### PR TITLE
fix: 動画パス解決のバグを修正

### DIFF
--- a/app/controllers/api/v1/videos_controller.rb
+++ b/app/controllers/api/v1/videos_controller.rb
@@ -95,14 +95,8 @@ module Api
       end
 
       def resolve_video_path(video_url)
-        # Handle relative paths from storage
-        if video_url.start_with?("/")
-          Rails.root.join(video_url.sub(/^\//, ""))
-        else
-          # For external URLs, we'd need different handling
-          # For now, assume local storage
-          Rails.root.join("storage", "videos", File.basename(video_url))
-        end
+        # Always resolve to storage/videos/ using the filename
+        Rails.root.join("storage", "videos", File.basename(video_url))
       end
 
       def stream_video(video_path)


### PR DESCRIPTION
## Summary
- `resolve_video_path` メソッドが `video_url="/videos/thoracic-twist.mp4"` のような `/` 始まりのパスを `Rails.root/videos/...`（存在しない）に解決していた
- 常に `File.basename` でファイル名を抽出し `storage/videos/` 配下に解決するよう修正
- これにより本番環境で動画が再生されない問題を解消

## Test plan
- [ ] CI のバックエンドテスト（`spec/requests/api/v1/videos_spec.rb`）が全パス
- [ ] Docker再ビルド後、本番で動画が再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)