### PR TITLE
fix: 職員ログイン画面のパスワードリセットリンクが機能しない問題を修正

### DIFF
--- a/frontend_admin/src/App.tsx
+++ b/frontend_admin/src/App.tsx
@@ -24,6 +24,7 @@ import { ReportGeneration } from './components/ReportGeneration'
 import { StaffManagement } from './components/StaffManagement'
 import { ExerciseMenuManagement } from './components/ExerciseMenuManagement'
 import { PasswordReset } from './components/PasswordReset'
+import { ForgotPassword } from './components/ForgotPassword'
 import { Sidebar } from './components/Sidebar'
 
 /**
@@ -252,6 +253,7 @@ export default function App() {
             {/* Public routes */}
             <Route path="/" element={<Navigate to="/login" replace />} />
             <Route path="/login" element={<Login />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
 
             {/* Authenticated routes with sidebar layout */}
             <Route element={<ProtectedRoute />}>

--- a/frontend_admin/src/components/ForgotPassword.tsx
+++ b/frontend_admin/src/components/ForgotPassword.tsx
@@ -1,0 +1,142 @@
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
+import { Heart, ArrowLeft, Mail } from 'lucide-react'
+import { api } from '../lib/api'
+
+export function ForgotPassword() {
+  const navigate = useNavigate()
+  const [staffId, setStaffId] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [validationError, setValidationError] = useState<string | undefined>()
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+
+    if (!staffId.trim()) {
+      setValidationError('職員IDを入力してください')
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      setSubmitError(null)
+      await api.requestStaffPasswordReset({ staff_id: staffId.trim() })
+      setIsSubmitted(true)
+    } catch {
+      // Backend always returns success for security (no information leakage).
+      // If it does fail (network error etc), show a generic message.
+      setSubmitError('リクエストの送信に失敗しました。しばらく待ってから再試行してください。')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleStaffIdChange = (value: string) => {
+    setStaffId(value)
+    if (validationError) {
+      setValidationError(undefined)
+    }
+    if (submitError) {
+      setSubmitError(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#F8FAFC] flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-lg p-8">
+          {/* Logo Area */}
+          <div className="flex flex-col items-center mb-8">
+            <div className="w-16 h-16 bg-[#1E40AF] rounded-2xl flex items-center justify-center mb-4">
+              <Heart size={32} className="text-white" fill="white" />
+            </div>
+
+            <h1 className="text-xl font-bold text-[#0B1220] mb-1">
+              パスワードリセット
+            </h1>
+            <p className="text-[#64748B] text-sm text-center">
+              職員IDを入力してください。登録されたメールアドレスにリセット手順を送信します。
+            </p>
+          </div>
+
+          {isSubmitted ? (
+            /* Success state */
+            <div className="text-center space-y-6">
+              <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto">
+                <Mail size={32} className="text-green-600" />
+              </div>
+              <div>
+                <p className="text-base font-medium text-[#0B1220] mb-2">
+                  メールを送信しました
+                </p>
+                <p className="text-sm text-[#64748B]">
+                  登録されたメールアドレスにパスワードリセットの手順を送信しました。メールをご確認ください。
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="primary"
+                size="lg"
+                className="w-full"
+                onClick={() => navigate('/login')}
+              >
+                ログイン画面に戻る
+              </Button>
+            </div>
+          ) : (
+            /* Form state */
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <Input
+                type="text"
+                label="職員ID"
+                placeholder="例: STF001"
+                value={staffId}
+                onChange={(e) => handleStaffIdChange(e.target.value)}
+                error={validationError}
+                disabled={isSubmitting}
+                autoComplete="username"
+              />
+
+              {submitError && (
+                <div
+                  role="alert"
+                  className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm"
+                >
+                  {submitError}
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant="primary"
+                size="lg"
+                className="w-full"
+                isLoading={isSubmitting}
+              >
+                {isSubmitting ? '送信中...' : 'リセットメールを送信'}
+              </Button>
+
+              <div className="text-center">
+                <button
+                  type="button"
+                  onClick={() => navigate('/login')}
+                  className="inline-flex items-center gap-1 text-[#1E40AF] hover:underline text-sm py-2 px-4 min-h-[44px]"
+                  disabled={isSubmitting}
+                >
+                  <ArrowLeft size={16} />
+                  ログイン画面に戻る
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ForgotPassword

--- a/frontend_admin/src/components/Login.tsx
+++ b/frontend_admin/src/components/Login.tsx
@@ -90,7 +90,7 @@ export function Login() {
   }
 
   const handlePasswordReset = () => {
-    navigate('/password-reset')
+    navigate('/forgot-password')
   }
 
   // Get first validation error for alert

--- a/frontend_admin/src/components/__tests__/ForgotPassword.test.tsx
+++ b/frontend_admin/src/components/__tests__/ForgotPassword.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { ForgotPassword } from '../ForgotPassword'
+
+// Mock api
+const mockRequestStaffPasswordReset = vi.fn()
+vi.mock('../../lib/api', () => ({
+  api: {
+    requestStaffPasswordReset: (...args: unknown[]) => mockRequestStaffPasswordReset(...args),
+  },
+}))
+
+// Mock useNavigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderForgotPassword() {
+  return render(
+    <BrowserRouter>
+      <ForgotPassword />
+    </BrowserRouter>
+  )
+}
+
+describe('ForgotPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('should render the form with title and staff ID input', () => {
+      renderForgotPassword()
+
+      expect(screen.getByText('パスワードリセット')).toBeInTheDocument()
+      expect(screen.getByLabelText('職員ID')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'リセットメールを送信' })).toBeInTheDocument()
+    })
+
+    it('should render description text', () => {
+      renderForgotPassword()
+
+      expect(
+        screen.getByText(/職員IDを入力してください/)
+      ).toBeInTheDocument()
+    })
+
+    it('should render back to login link', () => {
+      renderForgotPassword()
+
+      expect(screen.getByText('ログイン画面に戻る')).toBeInTheDocument()
+    })
+  })
+
+  describe('validation', () => {
+    it('should show error when staff ID is empty on submit', async () => {
+      const user = userEvent.setup()
+      renderForgotPassword()
+
+      await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('職員IDを入力してください')).toBeInTheDocument()
+      })
+      expect(mockRequestStaffPasswordReset).not.toHaveBeenCalled()
+    })
+
+    it('should clear validation error when user types', async () => {
+      const user = userEvent.setup()
+      renderForgotPassword()
+
+      await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('職員IDを入力してください')).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByLabelText('職員ID'), 'S')
+
+      expect(screen.queryByText('職員IDを入力してください')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('form submission', () => {
+    it('should call requestStaffPasswordReset on valid submit', async () => {
+      const user = userEvent.setup()
+      mockRequestStaffPasswordReset.mockResolvedValueOnce({
+        status: 'success',
+        data: { message: 'パスワードリセットのメールを送信しました' },
+      })
+
+      renderForgotPassword()
+
+      await user.type(screen.getByLabelText('職員ID'), 'STF001')
+      await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+      await waitFor(() => {
+        expect(mockRequestStaffPasswordReset).toHaveBeenCalledWith({
+          staff_id: 'STF001',
+        })
+      })
+    })
+
+    it('should show success message after successful submission', async () => {
+      const user = userEvent.setup()
+      mockRequestStaffPasswordReset.mockResolvedValueOnce({
+        status: 'success',
+        data: { message: 'パスワードリセットのメールを送信しました' },
+      })
+
+      renderForgotPassword()
+
+      await user.type(screen.getByLabelText('職員ID'), 'STF001')
+      await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('メールを送信しました')).toBeInTheDocument()
+      })
+      expect(
+        screen.getByText(/パスワードリセットの手順を送信しました/)
+      ).toBeInTheDocument()
+    })
+
+    it('should show back to login button after success', async () => {
+      const user = userEvent.setup()
+      mockRequestStaffPasswordReset.mockResolvedValueOnce({
+        status: 'success',
+        data: { message: 'ok' },
+      })
+
+      renderForgotPassword()
+
+      await user.type(screen.getByLabelText('職員ID'), 'STF001')
+      await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('メールを送信しました')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'ログイン画面に戻る' }))
+      expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+
+    it('should show error message on API failure', async () => {
+      const user = userEvent.setup()
+      mockRequestStaffPasswordReset.mockRejectedValueOnce(new Error('Network error'))
+
+      renderForgotPassword()
+
+      await user.type(screen.getByLabelText('職員ID'), 'STF001')
+      await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+        expect(
+          screen.getByText(/リクエストの送信に失敗しました/)
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('navigation', () => {
+    it('should navigate to login when back link is clicked', async () => {
+      const user = userEvent.setup()
+      renderForgotPassword()
+
+      await user.click(screen.getByText('ログイン画面に戻る'))
+
+      expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('should have accessible staff ID input with label', () => {
+      renderForgotPassword()
+
+      const input = screen.getByLabelText('職員ID')
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('type', 'text')
+    })
+
+    it('should have minimum tap target for buttons', () => {
+      renderForgotPassword()
+
+      const submitButton = screen.getByRole('button', { name: 'リセットメールを送信' })
+      expect(submitButton).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend_admin/src/components/__tests__/Login.test.tsx
+++ b/frontend_admin/src/components/__tests__/Login.test.tsx
@@ -226,7 +226,7 @@ describe('S-01 Staff Login', () => {
 
       await user.click(screen.getByText('パスワードをお忘れですか？'))
 
-      expect(mockNavigate).toHaveBeenCalledWith('/password-reset')
+      expect(mockNavigate).toHaveBeenCalledWith('/forgot-password')
     })
 
     it('should redirect to dashboard if already authenticated', () => {

--- a/frontend_admin/src/lib/api-types.ts
+++ b/frontend_admin/src/lib/api-types.ts
@@ -333,6 +333,15 @@ export interface ChangePasswordResponse {
   message: string
 }
 
+// Password Reset Request Types (Forgot Password)
+export interface StaffPasswordResetRequest {
+  staff_id: string
+}
+
+export interface PasswordResetResponse {
+  message: string
+}
+
 // Daily Condition Types (S-04 Patient Detail)
 export interface DailyCondition {
   id: string

--- a/frontend_admin/src/lib/api.ts
+++ b/frontend_admin/src/lib/api.ts
@@ -22,6 +22,8 @@ import type {
   CreateStaffResponse,
   ChangePasswordRequest,
   ChangePasswordResponse,
+  StaffPasswordResetRequest,
+  PasswordResetResponse,
   CreatePatientRequest,
   CreatePatientResponse,
   ExerciseMasterListResponse,
@@ -276,6 +278,11 @@ class ApiClient {
   // Password Change endpoint (S-09)
   async changePassword(data: ChangePasswordRequest): Promise<ApiResponse<ChangePasswordResponse>> {
     return this.post<ChangePasswordResponse>('/staff/me/password', data)
+  }
+
+  // Staff Password Reset Request (Forgot Password from login page)
+  async requestStaffPasswordReset(data: StaffPasswordResetRequest): Promise<ApiResponse<PasswordResetResponse>> {
+    return this.post<PasswordResetResponse>('/auth/password_reset_request', data)
   }
 
   // Patient Create endpoint (S-03)


### PR DESCRIPTION
ProtectedRoute内に配置されていたため未認証ユーザーがアクセスできなかった。
未認証用のForgotPassword画面を新規作成し、公開ルート /forgot-password に配置。 既存のバックエンドAPI (POST /auth/password_reset_request) を利用。