### PR TITLE
fix: デプロイ失敗時のログ出力を改善

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -110,8 +110,8 @@ done
 
 if [ "$HEALTH_OK" != true ]; then
   echo "ERROR: New container failed health check after 60 seconds"
-  echo "--- Container logs ---"
-  docker logs "$NEW_CONTAINER_NAME" 2>&1 | tail -20
+  echo "--- Container logs (last 80 lines) ---"
+  docker logs "$NEW_CONTAINER_NAME" 2>&1 | tail -80
   docker stop "$NEW_CONTAINER_NAME" || true
   rm -f "$ENV_FILE"
   exit 1


### PR DESCRIPTION
## Summary
- `bin/deploy.sh` のヘルスチェック失敗時のコンテナログ出力を `tail -20` → `tail -80` に増加
- PR #33 マージ後のデプロイ失敗で、実際のエラーメッセージが切れて見えなかった問題を解消

## Context
PR #33 のデプロイが失敗したが、コンテナログが20行しか表示されずスタックトレースの末尾のみ見えていた。
変更内容はドキュメント・スクリプトのみでRailsコード変更なしのため、一時的な障害の可能性が高い。
ログ出力改善+再デプロイで原因特定と復旧を行う。

## Test plan
- [ ] マージ後のデプロイが成功すること
- [ ] 万一失敗した場合、80行のコンテナログでエラー原因が特定できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)