### PR TITLE
fix: deploy.shのpipefail即死問題を修正

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -39,7 +39,7 @@ find_active_container() {
 
   # Extract target IP from kamal-proxy list output
   local target_ip
-  target_ip=$(echo "$proxy_output" | grep -oP '\d+\.\d+\.\d+\.\d+' | head -1)
+  target_ip=$(echo "$proxy_output" | grep -oP '\d+\.\d+\.\d+\.\d+' | head -1 || echo "")
 
   if [ -z "$target_ip" ]; then
     echo ""
@@ -47,9 +47,12 @@ find_active_container() {
   fi
 
   # Find container with that IP on the kamal network
-  docker network inspect kamal \
+  # Note: grep may return exit 1 if no match, so use || true to avoid pipefail exit
+  local container_name
+  container_name=$(docker network inspect kamal \
     --format '{{range .Containers}}{{.Name}} {{.IPv4Address}}{{"\n"}}{{end}}' 2>/dev/null | \
-    grep "$target_ip" | awk '{print $1}' | head -1
+    grep "$target_ip" | awk '{print $1}' | head -1 || echo "")
+  echo "$container_name"
 }
 
 CURRENT_CONTAINER=$(find_active_container)


### PR DESCRIPTION
## Summary
- `find_active_container` 関数内の `grep` パイプラインが `set -eo pipefail` と競合し、マッチなしの場合にスクリプトが即座に終了していた問題を修正
- `grep` の失敗を `|| echo ""` で安全に吸収するよう変更

## Root Cause
PR #33 のデプロイ失敗後、PR #34 のデプロイが11秒で即死した原因:
1. `grep -oP '\d+...'` がマッチなしで exit 1
2. `pipefail` によりパイプライン全体が非ゼロ終了
3. `set -e` によりスクリプトが即時終了

## Test plan
- [ ] マージ後のデプロイが Phase 1 を通過すること
- [ ] `find_active_container` が空文字を返した場合もスクリプトが継続すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)