### PR TITLE
fix: DB起動待ちリトライをdocker-entrypointに追加

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,7 +2,20 @@
 
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
-  ./bin/rails db:prepare
+  # Wait for database to be ready (max 30 attempts, 2 seconds apart)
+  echo "Waiting for database to be ready..."
+  for i in $(seq 1 30); do
+    if ./bin/rails db:prepare 2>&1; then
+      echo "Database ready."
+      break
+    fi
+    if [ "$i" -eq 30 ]; then
+      echo "ERROR: Database not ready after 60 seconds, exiting."
+      exit 1
+    fi
+    echo "Database not ready yet, retrying in 2 seconds... (${i}/30)"
+    sleep 2
+  done
 fi
 
 exec "${@}"


### PR DESCRIPTION
## Summary
- `bin/docker-entrypoint` に DB 接続リトライロジックを追加
- PostgreSQL がリカバリ中（`Consistent recovery state has not been yet reached`）に `db:prepare` が即失敗する問題を修正

## Root Cause
PR #37 のデプロイで環境変数抽出は成功したが、新コンテナ起動時に PostgreSQL がまだリカバリ中で `db:prepare` が即座に失敗:
```
FATAL: the database system is not yet accepting connections
DETAIL: Consistent recovery state has not been yet reached.
```

## Fix
`docker-entrypoint` で `db:prepare` を最大30回（60秒間）リトライ。DB がリカバリ完了するまで待機してからサーバー起動。

## Test plan
- [ ] デプロイワークフローが正常に完了する
- [ ] DB リカバリ中でもコンテナが正常に起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)