### PR TITLE
fix: pg_isreadyによる軽量DB接続チェックでデプロイタイムアウトを解消

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -138,18 +138,18 @@ NEW_IP=$(docker inspect "$NEW_CONTAINER_NAME" \
 echo "New container IP: ${NEW_IP}"
 
 HEALTH_OK=false
-for i in $(seq 1 30); do
+for i in $(seq 1 60); do
   if curl -sf --max-time 5 -H "Host: psytech.jp" "http://${NEW_IP}:3000/api/v1/health" > /dev/null 2>&1; then
     echo "Health check passed on attempt ${i}"
     HEALTH_OK=true
     break
   fi
-  echo "Waiting for health check... (${i}/30)"
-  sleep 2
+  echo "Waiting for health check... (${i}/60)"
+  sleep 3
 done
 
 if [ "$HEALTH_OK" != true ]; then
-  echo "ERROR: New container failed health check after 60 seconds"
+  echo "ERROR: New container failed health check after 180 seconds"
   echo "--- Container logs (last 80 lines) ---"
   docker logs "$NEW_CONTAINER_NAME" 2>&1 | tail -80
   docker stop "$NEW_CONTAINER_NAME" || true

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,19 +2,36 @@
 
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
-  # Wait for database to be ready (max 30 attempts, 2 seconds apart)
-  echo "Waiting for database to be ready..."
-  for i in $(seq 1 30); do
+  # Phase 1: Wait for PostgreSQL to accept connections (lightweight check)
+  echo "Waiting for PostgreSQL to accept connections..."
+  DB_HOST="${POSTGRES_HOST:-psyfit-db}"
+  DB_PORT="${POSTGRES_PORT:-5432}"
+  for i in $(seq 1 60); do
+    if pg_isready -h "$DB_HOST" -p "$DB_PORT" -q 2>/dev/null; then
+      echo "PostgreSQL is accepting connections (attempt ${i})."
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: PostgreSQL not ready after 120 seconds, exiting."
+      exit 1
+    fi
+    echo "PostgreSQL not ready yet, retrying in 2 seconds... (${i}/60)"
+    sleep 2
+  done
+
+  # Phase 2: Run db:prepare (migrate or create)
+  echo "Running database preparation..."
+  for i in $(seq 1 5); do
     if ./bin/rails db:prepare 2>&1; then
       echo "Database ready."
       break
     fi
-    if [ "$i" -eq 30 ]; then
-      echo "ERROR: Database not ready after 60 seconds, exiting."
+    if [ "$i" -eq 5 ]; then
+      echo "ERROR: db:prepare failed after 5 attempts, exiting."
       exit 1
     fi
-    echo "Database not ready yet, retrying in 2 seconds... (${i}/30)"
-    sleep 2
+    echo "db:prepare failed, retrying in 3 seconds... (${i}/5)"
+    sleep 3
   done
 fi
 


### PR DESCRIPTION
## Summary

- `docker-entrypoint`: `db:prepare`（重い操作）を接続チェック代わりに使っていた問題を修正。`pg_isready`で軽量チェック後、DB接続可能になってから`db:prepare`を1度だけ実行する2段階方式に変更
- `deploy.sh`: ヘルスチェックタイムアウトを60秒→180秒に拡大（PostgreSQL recovery mode完了を待つ時間を確保）

## 問題の原因

PostgreSQLが `recovery mode` 状態のままコンテナが起動し、`db:prepare`を繰り返し実行してもエラーが続いた。30回×2秒=60秒のリトライが尽き、デプロイヘルスチェックもタイムアウト。

## Test plan

- [ ] PRマージ後にDeploy Psyfit App workflowが成功することを確認
- [ ] コンテナ起動ログに `PostgreSQL is accepting connections` が表示されること
- [ ] `db:prepare` が1度だけ実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)