### PR TITLE
fix: デプロイ時に.envから不足環境変数をマージする処理を追加

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -99,6 +99,20 @@ if [ -n "$CURRENT_CONTAINER" ]; then
       > "$ENV_FILE" || true
   fi
 
+  # Merge missing variables from .env (e.g., newly added SMTP vars)
+  if [ -f "$APP_DIR/.env" ]; then
+    echo "--- Merging missing vars from .env ---"
+    while IFS= read -r line; do
+      # Skip comments and empty lines
+      [[ -z "$line" || "$line" =~ ^# ]] && continue
+      var_name="${line%%=*}"
+      if ! grep -q "^${var_name}=" "$ENV_FILE" 2>/dev/null; then
+        echo "$line" >> "$ENV_FILE"
+        echo "  Added from .env: ${var_name}"
+      fi
+    done < "$APP_DIR/.env"
+  fi
+
   # Update RAILS_MASTER_KEY to match repo
   if [ -f "$APP_DIR/config/master.key" ]; then
     master_key=$(cat "$APP_DIR/config/master.key")


### PR DESCRIPTION
## Summary
- `bin/deploy.sh` にて、旧コンテナからのenv抽出後に `.env` ファイルから不足変数を補完するマージ処理を追加
- SMTP変数など、`.env` に追加済みだがコンテナに未反映の環境変数がデプロイ時に自動注入される
- 既存のコンテナ変数は上書きしない（不足分のみ追加）

## Test plan
- [ ] デプロイ後にSMTP変数がコンテナ内で設定されていることを確認
- [ ] テストメール送信で動作確認
- [ ] 既存の環境変数が変更されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)