### PR TITLE
fix: 本番シードデータの職員名を修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,8 +105,9 @@ if Rails.env.production?
     { name: '山下大輝', role: 'staff' },
     { name: '児島雄貴', role: 'staff' },
     { name: '浅井菜々穂', role: 'staff' },
-    { name: '渡辺直仁', role: 'staff' },
-    { name: '吉田美希', role: 'staff' }
+    { name: '浅沼直樹', role: 'staff' },
+    { name: '山口桃佳', role: 'staff' },
+    { name: '吉川美希', role: 'staff' }
   ]
 
   created_staff = []


### PR DESCRIPTION
## Summary
- 本番シードデータの職員名の誤りを修正
  - 渡辺直仁 → 浅沼直樹
  - 吉田美希 → 吉川美希
  - 山口桃佳を新規追加（スタッフ10名 → 11名）

## デプロイ後の手順
マージ・自動デプロイ後、本番サーバーで以下を実行:

1. 旧スタッフアカウント削除（関連データ確認後）
2. `rails db:seed` で新しいアカウントを作成

```bash
# Docker コンテナ内で実行
docker exec -it <psyfit-web-container> bin/rails runner "
  ['渡辺直仁', '吉田美希'].each do |name|
    staff = Staff.find_by(name: name)
    if staff
      puts \"Deleting: #{staff.staff_id} (#{staff.name})\"
      staff.destroy!
    else
      puts \"Not found: #{name}\"
    end
  end
"
docker exec -it <psyfit-web-container> bin/rails db:seed
```

## Test plan
- [ ] CI パス確認（seeds.rb はテスト環境セクション変更なし）
- [ ] デプロイ後、本番で旧スタッフ削除 + seed 実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)