### PR TITLE
fix: staffテーブルから平文PIIカラムを削除

### DIFF
--- a/.claude/docs/03-database-schema.md
+++ b/.claude/docs/03-database-schema.md
@@ -51,24 +51,32 @@ exercises (運動マスタ)
 
 ### 2. staff (職員)
 
-| カラム名 | 型 | NULL | 説明 |
-|---------|-----|------|------|
-| id | UUID | NO | プライマリキー |
-| staff_id | VARCHAR(50) | NO | 職員ID (ログイン用) |
-| password_digest | VARCHAR(255) | NO | パスワードハッシュ |
-| name | VARCHAR(100) | NO | 職員氏名 |
-| email | VARCHAR(255) | NO | メールアドレス |
-| role | VARCHAR(20) | NO | 権限 (manager/staff) |
-| department | VARCHAR(100) | YES | 所属部署 |
-| failed_login_attempts | INTEGER | NO | ログイン失敗回数 |
-| locked_until | TIMESTAMP | YES | アカウントロック解除時刻 |
-| created_at | TIMESTAMP | NO | 作成日時 |
-| updated_at | TIMESTAMP | NO | 更新日時 |
-| deleted_at | TIMESTAMP | YES | 削除日時 |
+| カラム名 | 型 | NULL | 暗号化 | 説明 |
+|---------|-----|------|--------|------|
+| id | UUID | NO | - | プライマリキー |
+| staff_id | VARCHAR(50) | NO | - | 職員ID (ログイン用) |
+| password_digest | VARCHAR(255) | NO | - | パスワードハッシュ |
+| name_encrypted | VARCHAR | YES | AES-256-GCM | 職員氏名（暗号化） |
+| name_encrypted_iv | VARCHAR | YES | - | name暗号化IV |
+| name_kana_encrypted | VARCHAR | YES | AES-256-GCM | 職員氏名カナ（暗号化） |
+| name_kana_encrypted_iv | VARCHAR | YES | - | name_kana暗号化IV |
+| email_encrypted | VARCHAR | YES | AES-256-GCM | メールアドレス（暗号化） |
+| email_encrypted_iv | VARCHAR | YES | - | email暗号化IV |
+| email_bidx | VARCHAR | YES | HMAC-SHA256 | メール検索用ブラインドインデックス |
+| role | VARCHAR(20) | NO | - | 権限 (manager/staff) |
+| department | VARCHAR(100) | YES | - | 所属部署 |
+| failed_login_count | INTEGER | NO | - | ログイン失敗回数 |
+| locked_until | TIMESTAMP | YES | - | アカウントロック解除時刻 |
+| created_at | TIMESTAMP | NO | - | 作成日時 |
+| updated_at | TIMESTAMP | NO | - | 更新日時 |
+| deleted_at | TIMESTAMP | YES | - | 削除日時（論理削除） |
+
+**暗号化:** `attr_encrypted` gem による AES-256-GCM 暗号化。`name`, `name_kana`, `email` は仮想属性として復号データにアクセス。
 
 **インデックス:**
 - PRIMARY KEY (id)
 - UNIQUE INDEX (staff_id)
+- UNIQUE INDEX (email_bidx)
 - INDEX (role)
 
 ### 3. exercises (運動マスタ)

--- a/app/controllers/api/v1/staff_controller.rb
+++ b/app/controllers/api/v1/staff_controller.rb
@@ -42,7 +42,9 @@ module Api
       # GET /api/v1/staff/options
       # Returns minimal staff list for dropdown filters (accessible to all authenticated staff)
       def options
-        staff_members = Staff.active.order(:name)
+        staff_members = Staff.active.order(:staff_id)
+
+        log_audit("read", "success")
 
         render_success({
           staff_options: staff_members.map { |s| { id: s.id, name: s.name } }

--- a/db/migrate/20260214165444_remove_plaintext_pii_from_staff.rb
+++ b/db/migrate/20260214165444_remove_plaintext_pii_from_staff.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Remove plaintext PII columns from staff table.
+# These columns were kept during the initial encryption migration
+# (20260122100001_encrypt_staff_pii_fields.rb) and are no longer needed
+# since all data is now stored in encrypted columns (*_encrypted, *_encrypted_iv).
+#
+# Security: Eliminates plaintext PII exposure risk for staff records.
+class RemovePlaintextPiiFromStaff < ActiveRecord::Migration[8.1]
+  def up
+    # Safety check: verify all staff records have encrypted data
+    # for required PII fields before removing plaintext columns
+    missing = execute(<<~SQL).to_a
+      SELECT id FROM staff
+      WHERE name_encrypted IS NULL OR name_encrypted = ''
+         OR email_encrypted IS NULL OR email_encrypted = ''
+    SQL
+
+    if missing.any?
+      raise "Aborting: #{missing.count} staff record(s) missing encrypted name/email data. " \
+            "IDs: #{missing.map { |r| r['id'] }.join(', ')}"
+    end
+
+    remove_column :staff, :name, :string
+    remove_column :staff, :name_kana, :string
+    remove_column :staff, :email, :string
+  end
+
+  def down
+    add_column :staff, :name, :string
+    add_column :staff, :name_kana, :string
+    add_column :staff, :email, :string
+
+    # Restore plaintext data from encrypted columns
+    Staff.reset_column_information
+    reversible_restore_count = 0
+    Staff.find_each do |staff|
+      # attr_encrypted virtual attributes decrypt from *_encrypted columns
+      staff.update_columns(
+        name: staff.name,
+        name_kana: staff.name_kana,
+        email: staff.email
+      )
+      reversible_restore_count += 1
+    end
+    say "Restored plaintext data for #{reversible_restore_count} staff records"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_09_142811) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_14_165444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -148,16 +148,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_09_142811) do
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.string "department"
-    t.string "email"
     t.string "email_bidx"
     t.string "email_encrypted"
     t.string "email_encrypted_iv"
     t.integer "failed_login_count", default: 0, null: false
     t.datetime "locked_until"
-    t.string "name", null: false
     t.string "name_encrypted"
     t.string "name_encrypted_iv"
-    t.string "name_kana"
     t.string "name_kana_encrypted"
     t.string "name_kana_encrypted_iv"
     t.string "password_digest", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,28 +92,28 @@ if Rails.env.production?
 
   production_staff = [
     # マネージャー
-    { name: '西野智之', role: 'manager' },
-    { name: '稲葉樹生', role: 'manager' },
-    { name: '尾崎純', role: 'manager' },
-    { name: '黒木怜', role: 'manager' },
+    { staff_id: 'MGR001', name: '西野智之', role: 'manager' },
+    { staff_id: 'MGR002', name: '稲葉樹生', role: 'manager' },
+    { staff_id: 'MGR003', name: '尾崎純', role: 'manager' },
+    { staff_id: 'MGR004', name: '黒木怜', role: 'manager' },
     # スタッフ
-    { name: '大木宏輔', role: 'staff' },
-    { name: '鈴木亮陽', role: 'staff' },
-    { name: '田中涼乃', role: 'staff' },
-    { name: '藤崎彩矢', role: 'staff' },
-    { name: '中西健人', role: 'staff' },
-    { name: '山下大輝', role: 'staff' },
-    { name: '児島雄貴', role: 'staff' },
-    { name: '浅井菜々穂', role: 'staff' },
-    { name: '浅沼直樹', role: 'staff' },
-    { name: '山口桃佳', role: 'staff' },
-    { name: '吉川美希', role: 'staff' }
+    { staff_id: 'STF001', name: '大木宏輔', role: 'staff' },
+    { staff_id: 'STF002', name: '鈴木亮陽', role: 'staff' },
+    { staff_id: 'STF003', name: '田中涼乃', role: 'staff' },
+    { staff_id: 'STF004', name: '藤崎彩矢', role: 'staff' },
+    { staff_id: 'STF005', name: '中西健人', role: 'staff' },
+    { staff_id: 'STF006', name: '山下大輝', role: 'staff' },
+    { staff_id: 'STF007', name: '児島雄貴', role: 'staff' },
+    { staff_id: 'STF008', name: '浅井菜々穂', role: 'staff' },
+    { staff_id: 'STF009', name: '浅沼直樹', role: 'staff' },
+    { staff_id: 'STF010', name: '山口桃佳', role: 'staff' },
+    { staff_id: 'STF011', name: '吉川美希', role: 'staff' }
   ]
 
   created_staff = []
   production_staff.each do |data|
-    # staff_id はモデルの before_validation で自動生成（MGR001〜, STF001〜）
-    staff = Staff.find_or_initialize_by(name: data[:name]) do |s|
+    staff = Staff.find_or_initialize_by(staff_id: data[:staff_id]) do |s|
+      s.name = data[:name]
       s.role = data[:role]
       s.password = temp_password
     end


### PR DESCRIPTION
## Summary
- セキュリティ監査で発見された `staff` テーブルの平文PIIカラム（`name`, `name_kana`, `email`）を削除
- 暗号化カラム（`*_encrypted`）にデータが正しく存在することを安全チェック後に削除するreversibleマイグレーションを作成
- 平文カラムを参照していた `staff_controller.rb` の `order(:name)` と `seeds.rb` の `find_or_initialize_by(name:)` を修正

## Changes
- **マイグレーション**: `name_encrypted`/`email_encrypted` の存在を検証してから平文カラムを削除。ロールバック時は暗号化データから復元
- **staff_controller.rb**: `options` アクションの `order(:name)` → `order(:staff_id)` + 監査ログ追加
- **seeds.rb**: 本番シードの lookup を `name` → `staff_id` に変更（冪等性を `staff_id` で保証）
- **テスト**: `GET /api/v1/staff/options` エンドポイントのテスト5件追加（順序、属性、監査ログ、論理削除除外、認証）
- **ドキュメント**: `03-database-schema.md` の staff テーブル定義を暗号化カラムに更新

## Test plan
- [x] 全589テストパス（カバレッジ 91.87%）
- [x] マイグレーション正常実行
- [x] ロールバック動作確認（平文データ復元）
- [x] 暗号化データの復号確認（`Staff.first.name` 等）
- [x] シードデータ実行確認（開発環境）
- [ ] CI全パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)