### PR TITLE
fix: 本番シードデータの実名をダミー名に差し替え

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@
 #
 # 環境ごとにシードデータを分岐:
 #   - 全環境: 運動マスタ（Exercise）+ 動画（Video）
-#   - production: 本番職員アカウント（マネージャー4名 + スタッフ10名）
+#   - production: 本番職員アカウント（マネージャー4名 + スタッフ11名）
 #   - development/test: テスト用職員・患者・ダミー業務データ
 
 puts "Seeding database (#{Rails.env})..."
@@ -92,22 +92,22 @@ if Rails.env.production?
 
   production_staff = [
     # マネージャー
-    { staff_id: 'MGR001', name: '西野智之', role: 'manager' },
-    { staff_id: 'MGR002', name: '稲葉樹生', role: 'manager' },
-    { staff_id: 'MGR003', name: '尾崎純', role: 'manager' },
-    { staff_id: 'MGR004', name: '黒木怜', role: 'manager' },
+    { staff_id: 'MGR001', name: '管理 太郎', role: 'manager' },
+    { staff_id: 'MGR002', name: '管理 次郎', role: 'manager' },
+    { staff_id: 'MGR003', name: '管理 三郎', role: 'manager' },
+    { staff_id: 'MGR004', name: '管理 四郎', role: 'manager' },
     # スタッフ
-    { staff_id: 'STF001', name: '大木宏輔', role: 'staff' },
-    { staff_id: 'STF002', name: '鈴木亮陽', role: 'staff' },
-    { staff_id: 'STF003', name: '田中涼乃', role: 'staff' },
-    { staff_id: 'STF004', name: '藤崎彩矢', role: 'staff' },
-    { staff_id: 'STF005', name: '中西健人', role: 'staff' },
-    { staff_id: 'STF006', name: '山下大輝', role: 'staff' },
-    { staff_id: 'STF007', name: '児島雄貴', role: 'staff' },
-    { staff_id: 'STF008', name: '浅井菜々穂', role: 'staff' },
-    { staff_id: 'STF009', name: '浅沼直樹', role: 'staff' },
-    { staff_id: 'STF010', name: '山口桃佳', role: 'staff' },
-    { staff_id: 'STF011', name: '吉川美希', role: 'staff' }
+    { staff_id: 'STF001', name: '職員 一郎', role: 'staff' },
+    { staff_id: 'STF002', name: '職員 二郎', role: 'staff' },
+    { staff_id: 'STF003', name: '職員 花子', role: 'staff' },
+    { staff_id: 'STF004', name: '職員 四郎', role: 'staff' },
+    { staff_id: 'STF005', name: '職員 五郎', role: 'staff' },
+    { staff_id: 'STF006', name: '職員 六郎', role: 'staff' },
+    { staff_id: 'STF007', name: '職員 七郎', role: 'staff' },
+    { staff_id: 'STF008', name: '職員 八重', role: 'staff' },
+    { staff_id: 'STF009', name: '職員 九郎', role: 'staff' },
+    { staff_id: 'STF010', name: '職員 十子', role: 'staff' },
+    { staff_id: 'STF011', name: '職員 十一郎', role: 'staff' }
   ]
 
   created_staff = []


### PR DESCRIPTION
## Summary

- `db/seeds.rb` の本番シードデータ（production_staff配列）に含まれていた実在の職員名15名をダミー名に差し替え
- マネージャー: 管理 太郎〜四郎、スタッフ: 職員 一郎〜十一郎
- コメントのスタッフ人数を「10名」→「11名」に修正

## Why

ソースコード上にPII（個人識別情報）が平文で存在するセキュリティリスクを解消。
DB上のデータは `attr_encrypted` で暗号化済みだが、seeds.rb のソースに実名が残っていた。

## Impact

- 本番DBの既存データに影響なし（`find_or_initialize_by(staff_id:)` で検索、name は新規作成時のみ設定）
- 開発環境のseed再実行も問題なし

## Test plan

- [x] RSpec 589 examples, 0 failures
- [x] Coverage: 91.87%
- [x] Code review: セキュリティ確認済み

## Note

Git履歴には旧データが残っています。必要に応じて `git filter-repo` での履歴書き換えを検討してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)