### PR TITLE
fix: 職員編集・型定義でも部署フィールドを任意に変更

### DIFF
--- a/frontend_admin/src/components/EditStaffDialog.tsx
+++ b/frontend_admin/src/components/EditStaffDialog.tsx
@@ -10,7 +10,6 @@ interface FormErrors {
   name?: string
   name_kana?: string
   email?: string
-  department?: string
 }
 
 interface EditStaffDialogProps {
@@ -75,10 +74,6 @@ export function EditStaffDialog({ isOpen, onClose, onSuccess, staff }: EditStaff
       newErrors.email = 'メールアドレスを入力してください'
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
       newErrors.email = '有効なメールアドレスを入力してください'
-    }
-
-    if (!formData.department?.trim()) {
-      newErrors.department = '部署を入力してください'
     }
 
     setErrors(newErrors)
@@ -305,7 +300,7 @@ export function EditStaffDialog({ isOpen, onClose, onSuccess, staff }: EditStaff
                 htmlFor="edit-department"
                 className="block text-sm font-medium text-gray-700 mb-1"
               >
-                部署 <span className="text-red-500">*</span>
+                部署
               </label>
               <input
                 id="edit-department"
@@ -313,14 +308,7 @@ export function EditStaffDialog({ isOpen, onClose, onSuccess, staff }: EditStaff
                 value={formData.department || ''}
                 onChange={(e) => handleChange('department', e.target.value)}
                 className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#1E40AF] focus:border-transparent text-base min-h-[44px]"
-                aria-invalid={!!errors.department}
-                aria-describedby={errors.department ? 'edit-department-error' : undefined}
               />
-              {errors.department && (
-                <p id="edit-department-error" role="alert" className="mt-1 text-sm text-red-600">
-                  {errors.department}
-                </p>
-              )}
             </div>
 
             {/* Submit Error */}

--- a/frontend_admin/src/lib/api-types.ts
+++ b/frontend_admin/src/lib/api-types.ts
@@ -220,7 +220,7 @@ export interface StaffMember {
   name_kana: string
   email: string
   role: 'manager' | 'staff'
-  department: string
+  department?: string
   created_at: string
 }
 
@@ -240,7 +240,7 @@ export interface CreateStaffRequest {
   email: string
   password: string
   role: 'manager' | 'staff'
-  department: string
+  department?: string
 }
 
 export interface CreateStaffResponse {


### PR DESCRIPTION
## Summary
- `EditStaffDialog` の部署バリデーション・必須マーク・エラー表示を削除
- `api-types.ts` の `StaffMember.department` と `CreateStaffRequest.department` を optional に変更
- #56 で `CreateStaffDialog` のみ修正されていたが、編集ダイアログと型定義に必須制約が残っていた問題を修正

## Test plan
- [ ] 職員新規登録：部署未入力で登録成功すること
- [ ] 職員編集：部署を空にして更新成功すること
- [ ] 他の必須フィールドのバリデーションが引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)