### PR TITLE
fix: SPA index.htmlにno-cacheヘッダーを設定

### DIFF
--- a/app/controllers/spa_controller.rb
+++ b/app/controllers/spa_controller.rb
@@ -2,12 +2,24 @@
 
 # Serves React SPA index.html files for client-side routing.
 # All non-API paths are handled here to support browser history navigation.
+# index.html must not be cached long-term so that new deploys (with updated
+# asset hashes) are picked up immediately by browsers.
 class SpaController < ActionController::Base
+  before_action :set_no_cache_headers
+
   def user_index
     render file: Rails.public_path.join("index.html"), layout: false
   end
 
   def admin_index
     render file: Rails.public_path.join("admin", "index.html"), layout: false
+  end
+
+  private
+
+  def set_no_cache_headers
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
   end
 end


### PR DESCRIPTION
## Summary
- `SpaController` で `index.html` レスポンスに `Cache-Control: no-cache, no-store, must-revalidate` を付与
- デプロイ後にブラウザが古い `index.html` をキャッシュし続け、フロントエンド変更（部署フィールド任意化等）が反映されない問題を修正

## 根本原因
Railsの `config.public_file_server.headers` で全静的ファイルに `max-age=1年` が設定されている。ハッシュ付きJS/CSSは問題ないが、`index.html` は常に同じパスのため、ブラウザが古いバージョンをキャッシュし続け、古いJSハッシュを参照してしまっていた。

## 修正内容
| ファイル | 変更 |
|---------|------|
| `app/controllers/spa_controller.rb` | `before_action :set_no_cache_headers` で `index.html` に no-cache を設定 |

ハッシュ付きアセット (`index-xxx.js`, `index-xxx.css`) は引き続き long-term キャッシュが有効なので、パフォーマンスへの影響はありません。

## Test plan
- [ ] デプロイ後にブラウザキャッシュクリアなしで最新の画面が表示されること
- [ ] `/admin` アクセス時のレスポンスヘッダーに `Cache-Control: no-cache` が含まれること
- [ ] JS/CSSアセットは引き続きキャッシュされること（`max-age` が長い）

🤖 Generated with [Claude Code](https://claude.com/claude-code)