### PR TITLE
feat: 音声読み上げ機能と字幕表示の改善

### DIFF
--- a/frontend_user/src/components/ExercisePlayer.tsx
+++ b/frontend_user/src/components/ExercisePlayer.tsx
@@ -38,6 +38,8 @@ export function ExercisePlayer() {
   const targetRepsRef = useRef(1)
   const repsPerVideoRef = useRef(1)
   const countedThresholdsRef = useRef<Set<number>>(new Set())
+  const advicesRef = useRef<string[]>([])
+  const adviceIndexRef = useRef(0)
   const { isFullscreen, enterFullscreen, exitFullscreen } = useFullscreenPlayer()
   const { speak, stop } = useSpeechSynthesis()
 
@@ -71,10 +73,13 @@ export function ExercisePlayer() {
     fetchExercise()
   }, [isAuthenticated, id])
 
-  // targetReps と repsPerVideo を ref に同期
+  // targetReps と repsPerVideo と advices を ref に同期
   useEffect(() => {
     targetRepsRef.current = exercise?.reps ?? 1
     repsPerVideoRef.current = exercise?.reps_per_video ?? 1
+    advicesRef.current = exercise?.description
+      ? exercise.description.split('\n').map(l => l.replace(/^・/, '').trim()).filter(Boolean)
+      : []
   }, [exercise])
 
   // Fetch video token after exercise is loaded
@@ -139,13 +144,19 @@ export function ExercisePlayer() {
       if (videoRef.current) {
         isLooping.current = true
         videoRef.current.currentTime = 0
+        // 音声をリセットして次のアドバイスを読む
+        stop()
+        adviceIndexRef.current++
+        if (advicesRef.current.length > 0) {
+          speak(advicesRef.current[adviceIndexRef.current % advicesRef.current.length] ?? '')
+        }
         videoRef.current.play().catch(() => {
           isLooping.current = false
           setIsPlaying(false)
         })
       }
     }
-  }, [])
+  }, [stop, speak])
 
   const handlePlayPause = () => {
     if (isPlaying) {
@@ -166,9 +177,9 @@ export function ExercisePlayer() {
         videoRef.current?.play().catch(() => setIsPlaying(false))
         setIsPlaying(true)
       }
-      // 再生開始時に読み上げ（iOS対策: ユーザージェスチャーのコールスタック内で呼ぶ）
-      if (exercise?.description) {
-        speak(exercise.description)
+      // 再生開始時に現在のアドバイスを読み上げ（iOS対策: ユーザージェスチャーのコールスタック内で呼ぶ）
+      if (advicesRef.current.length > 0) {
+        speak(advicesRef.current[adviceIndexRef.current % advicesRef.current.length] ?? '')
       }
     }
   }
@@ -199,6 +210,7 @@ export function ExercisePlayer() {
     loopCountRef.current = 0
     setLoopCount(0)
     countedThresholdsRef.current = new Set()
+    adviceIndexRef.current = 0
     if (videoRef.current) {
       videoRef.current.currentTime = 0
     }
@@ -213,8 +225,9 @@ export function ExercisePlayer() {
       if (videoRef.current) {
         videoRef.current.currentTime = 0
       }
-      if (exercise.description) {
-        speak(exercise.description)
+      adviceIndexRef.current = 0
+      if (advicesRef.current.length > 0) {
+        speak(advicesRef.current[0] ?? '')
       }
     }
   }

--- a/frontend_user/src/components/ExercisePlayer.tsx
+++ b/frontend_user/src/components/ExercisePlayer.tsx
@@ -31,6 +31,7 @@ export function ExercisePlayer() {
   const [videoError, setVideoError] = useState<string | null>(null)
   const [viewMode, setViewMode] = useState<'video' | 'camera'>('video')
   const [showCameraSkeleton, setShowCameraSkeleton] = useState(false)
+  const [currentAdvice, setCurrentAdvice] = useState<string>('')
 
   const videoRef = useRef<HTMLVideoElement>(null)
   const isLooping = useRef(false)
@@ -80,6 +81,7 @@ export function ExercisePlayer() {
     advicesRef.current = exercise?.description
       ? exercise.description.split('\n').map(l => l.replace(/^・/, '').trim()).filter(Boolean)
       : []
+    setCurrentAdvice(advicesRef.current[0] ?? '')
   }, [exercise])
 
   // Fetch video token after exercise is loaded
@@ -148,7 +150,9 @@ export function ExercisePlayer() {
         stop()
         adviceIndexRef.current++
         if (advicesRef.current.length > 0) {
-          speak(advicesRef.current[adviceIndexRef.current % advicesRef.current.length] ?? '')
+          const nextAdvice = advicesRef.current[adviceIndexRef.current % advicesRef.current.length] ?? ''
+          speak(nextAdvice)
+          setCurrentAdvice(nextAdvice)
         }
         videoRef.current.play().catch(() => {
           isLooping.current = false
@@ -179,7 +183,9 @@ export function ExercisePlayer() {
       }
       // 再生開始時に現在のアドバイスを読み上げ（iOS対策: ユーザージェスチャーのコールスタック内で呼ぶ）
       if (advicesRef.current.length > 0) {
-        speak(advicesRef.current[adviceIndexRef.current % advicesRef.current.length] ?? '')
+        const advice = advicesRef.current[adviceIndexRef.current % advicesRef.current.length] ?? ''
+        speak(advice)
+        setCurrentAdvice(advice)
       }
     }
   }
@@ -211,6 +217,7 @@ export function ExercisePlayer() {
     setLoopCount(0)
     countedThresholdsRef.current = new Set()
     adviceIndexRef.current = 0
+    setCurrentAdvice(advicesRef.current[0] ?? '')
     if (videoRef.current) {
       videoRef.current.currentTime = 0
     }
@@ -227,7 +234,9 @@ export function ExercisePlayer() {
       }
       adviceIndexRef.current = 0
       if (advicesRef.current.length > 0) {
-        speak(advicesRef.current[0] ?? '')
+        const firstAdvice = advicesRef.current[0] ?? ''
+        speak(firstAdvice)
+        setCurrentAdvice(firstAdvice)
       }
     }
   }
@@ -372,6 +381,7 @@ export function ExercisePlayer() {
           showCameraSkeleton={showCameraSkeleton}
           onViewModeToggle={handleViewModeToggle}
           onCameraSkeletonToggle={() => setShowCameraSkeleton(prev => !prev)}
+          currentAdvice={currentAdvice}
         />
       )}
 
@@ -438,6 +448,11 @@ export function ExercisePlayer() {
       <main className={`flex-1 bg-white ${isFullscreen ? 'hidden' : ''}`}>
         {/* Set counter with live region */}
         <div className="px-4 py-4 border-b border-gray-100">
+          {currentAdvice && (
+            <p className="text-center text-[#1E40AF] text-lg font-medium mb-3">
+              {currentAdvice}
+            </p>
+          )}
           <div
             role="status"
             aria-live="polite"

--- a/frontend_user/src/components/ExercisePlayerFullscreenOverlay.tsx
+++ b/frontend_user/src/components/ExercisePlayerFullscreenOverlay.tsx
@@ -25,6 +25,7 @@ interface ExercisePlayerFullscreenOverlayProps {
   showCameraSkeleton: boolean
   onViewModeToggle: () => void
   onCameraSkeletonToggle: () => void
+  currentAdvice?: string
 }
 
 const AUTO_HIDE_DELAY = 3000
@@ -52,6 +53,7 @@ export function ExercisePlayerFullscreenOverlay({
   showCameraSkeleton,
   onViewModeToggle,
   onCameraSkeletonToggle,
+  currentAdvice,
 }: ExercisePlayerFullscreenOverlayProps) {
   // 種目名・再生ボタンのみ auto-hide
   const [showTopControls, setShowTopControls] = useState(true)
@@ -221,6 +223,12 @@ export function ExercisePlayerFullscreenOverlay({
 
       {/* Bottom bar — セット数・回数・ボタン (常時表示) */}
       <div className="absolute bottom-0 inset-x-0 z-10 px-4 py-4 pb-[max(1rem,env(safe-area-inset-bottom))] bg-gradient-to-t from-black/70 to-transparent">
+        {/* アドバイス文章 */}
+        {currentAdvice && (
+          <p className="text-white/90 text-lg font-medium text-center mb-2">
+            {currentAdvice}
+          </p>
+        )}
         {/* カウンター */}
         <div className="flex items-center gap-4 mb-3">
           <div

--- a/frontend_user/src/components/__tests__/ExercisePlayer.test.tsx
+++ b/frontend_user/src/components/__tests__/ExercisePlayer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ExercisePlayer } from '../ExercisePlayer'
@@ -617,6 +617,106 @@ describe('U-04 ExercisePlayer', () => {
       await user.click(closeButton)
 
       expect(window.speechSynthesis.cancel).toHaveBeenCalled()
+    })
+
+    describe('アドバイスサイクリング', () => {
+      const multiAdviceExercise: Exercise = {
+        ...mockExercise,
+        description: '・アドバイス1\n・アドバイス2\n・アドバイス3',
+        reps: 5,
+      }
+
+      beforeEach(() => {
+        mockGetExercise.mockResolvedValue({
+          status: 'success',
+          data: multiAdviceExercise,
+        })
+      })
+
+      it('初回再生時にアドバイス1が読み上げられる', async () => {
+        const user = userEvent.setup()
+        renderExercisePlayer()
+
+        await waitFor(() => {
+          expect(screen.getByText('膝伸展運動')).toBeInTheDocument()
+        })
+
+        const playButton = screen.getByRole('button', { name: /再生/ })
+        await user.click(playButton)
+
+        const calls = (window.speechSynthesis.speak as ReturnType<typeof vi.fn>).mock.calls
+        const texts = calls.map((c: unknown[]) => (c[0] as { text: string }).text)
+        expect(texts).toContain('アドバイス1')
+        expect(texts).not.toContain('アドバイス2')
+      })
+
+      it('動画1回目終了後にアドバイス2が読み上げられる', async () => {
+        const user = userEvent.setup()
+        renderExercisePlayer()
+
+        await waitFor(() => {
+          expect(screen.getByText('膝伸展運動')).toBeInTheDocument()
+        })
+
+        const playButton = screen.getByRole('button', { name: /再生/ })
+        await user.click(playButton)
+
+        // 1回目のループ完了
+        const video = screen.getByTestId('fullscreen-video')
+        fireEvent(video, new Event('ended'))
+
+        const calls = (window.speechSynthesis.speak as ReturnType<typeof vi.fn>).mock.calls
+        const texts = calls.map((c: unknown[]) => (c[0] as { text: string }).text)
+        expect(texts).toContain('アドバイス2')
+      })
+
+      it('動画3回目終了後（アドバイスが3つ）にアドバイス1に循環する', async () => {
+        const user = userEvent.setup()
+        renderExercisePlayer()
+
+        await waitFor(() => {
+          expect(screen.getByText('膝伸展運動')).toBeInTheDocument()
+        })
+
+        const playButton = screen.getByRole('button', { name: /再生/ })
+        await user.click(playButton)
+
+        const video = screen.getByTestId('fullscreen-video')
+        // 3回ループ（アドバイス1→2→3→1に循環）
+        fireEvent(video, new Event('ended')) // adviceIndex: 1 → advice2
+        fireEvent(video, new Event('ended')) // adviceIndex: 2 → advice3
+        fireEvent(video, new Event('ended')) // adviceIndex: 3 % 3 = 0 → advice1
+
+        const calls = (window.speechSynthesis.speak as ReturnType<typeof vi.fn>).mock.calls
+        const lastCall = calls[calls.length - 1]
+        const lastText = lastCall ? (lastCall[0] as { text: string }).text : ''
+        expect(lastText).toBe('アドバイス1')
+      })
+
+      it('次のセットへ遷移するとアドバイスインデックスが0にリセットされる', async () => {
+        const user = userEvent.setup()
+        renderExercisePlayer()
+
+        await waitFor(() => {
+          expect(screen.getByText('膝伸展運動')).toBeInTheDocument()
+        })
+
+        const playButton = screen.getByRole('button', { name: /再生/ })
+        await user.click(playButton)
+
+        // ループしてアドバイス2になる
+        const video = screen.getByTestId('fullscreen-video')
+        fireEvent(video, new Event('ended'))
+
+        // 次のセットへ（インデックスリセット → アドバイス1）
+        const nextSetButton = screen.getByRole('button', { name: /次のセット/ })
+        await user.click(nextSetButton)
+
+        const calls = (window.speechSynthesis.speak as ReturnType<typeof vi.fn>).mock.calls
+        const lastCall = calls[calls.length - 1]
+        const lastText = lastCall ? (lastCall[0] as { text: string }).text : ''
+        expect(lastText).toBe('アドバイス1')
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- 音声読み上げを「1動画再生につき1アドバイス」に変更  
  動画がループするたびにアドバイスを1件ずつ順番に読み上げ（最後まで来たら先頭に戻る）
- アドバイス字幕をセット数・回数表示の上に表示するよう変更
- 字幕も音声と同じく1動画1アドバイス形式で切り替わるよう対応

## Test plan

- [ ] アドバイスが3件ある運動で、ループごとに順番に切り替わることを確認
- [ ] アドバイス件数を超えても先頭に戻り循環することを確認
- [ ] 字幕がセット数・回数の上に表示されることを確認
- [ ] 音声と字幕が同じアドバイス番号を指していることを確認
- [ ] アドバイスが0件の場合に字幕・音声が出ないことを確認